### PR TITLE
done

### DIFF
--- a/backend/models/Exercise.js
+++ b/backend/models/Exercise.js
@@ -34,6 +34,10 @@ const exerciseSchema = new mongoose.Schema({
             message: 'Difficulty must be either beginner, intermediate, or advanced'
         }
     },
+    createdAt: {
+        type: Date,
+        default: Date.now
+    },
     videoUrl: String,
     imageUrl: String,
     createdBy: {
@@ -41,10 +45,7 @@ const exerciseSchema = new mongoose.Schema({
         ref: 'User',
         required: [true, 'An exercise must be created by a user']
     },
-    createdAt: {
-        type: Date,
-        default: Date.now
-    }
+    
 });
 
 const Exercise = mongoose.model('Exercise', exerciseSchema);

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -21,14 +21,15 @@ const userSchema = new mongoose.Schema({
         type: String,
         default: ''
     },
+    
+    createdAt: {
+        type: Date,
+        default: Date.now
+    },
     savedWorkouts: [{
         type: mongoose.Schema.Types.ObjectId,
         ref: 'Workout'
     }],
-    createdAt: {
-        type: Date,
-        default: Date.now
-    }
 });
 
 module.exports = mongoose.model('User', userSchema); 


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Refactored `createdAt` field placement in `Exercise` and `User` schemas

- Improved schema organization for clarity and maintainability


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Exercise.js</strong><dd><code>Refactor `createdAt` field placement in Exercise schema</code>&nbsp; &nbsp; </dd></summary>
<hr>

backend/models/Exercise.js

<li>Moved <code>createdAt</code> field above <code>videoUrl</code> and <code>imageUrl</code> for better <br>organization<br> <li> Removed duplicate <code>createdAt</code> field at the end of the schema<br> <li> No changes to schema logic or validation


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S85_Sanya_Capstone_Luma_Life/pull/19/files#diff-617ca62758a8d2de100a567eb3d74c13cb8264ea00e2499975e81b954d5211b9">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>User.js</strong><dd><code>Refactor `createdAt` field placement in User schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/models/User.js

<li>Moved <code>createdAt</code> field above <code>savedWorkouts</code> for consistency<br> <li> Removed duplicate <code>createdAt</code> field at the end of the schema<br> <li> No changes to schema logic or validation


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S85_Sanya_Capstone_Luma_Life/pull/19/files#diff-a6d07b5297ce9bf405466645a67e1f98bc73533b55c042490553a04fe946de87">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>